### PR TITLE
Bugfix: Invalid BlueTag href value

### DIFF
--- a/components/portal/guides-list/index.tsx
+++ b/components/portal/guides-list/index.tsx
@@ -30,7 +30,7 @@ export const GuidesList: React.FC<GuidesListProps> = ({
         >
           <BlueTag name="All" href="/guides" />
           <BlueTag name="TypeScript" href="/guides/tag/typescript" />
-          <BlueTag name="React" href="/guides/react" />
+          <BlueTag name="React" href="/guides/tag/react" />
           <BlueTag name="Python" href="/guides/tag/python" />
           <BlueTag name="No code" href="/guides/tag/no-code" />
           <BlueTag name="NFT Collection" href="/guides/nft-collection" />


### PR DESCRIPTION
Issue: 
The portal resource to "React" under "Featured Guides" is broken. 
https://portal.thirdweb.com/

Update:
Updated path to include '/tag' in the href attribute in the BlueTag.

